### PR TITLE
Setting up RHEV-H and RHEV-M works for me now 

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -84,3 +84,31 @@ The following roles exist:
 - **layer2_rhosp_overcloud**: deploys Red Hat OpenStack (overcloud) on the nodes prepared by director. This is still work in progress (runs for about 45 mins).
 
 All other roles are not yet usable.
+
+### Network Connectivity
+
+In order to access the virtual machines created on layer2, a tunneling mechanism is used. Ansible connects to the layer1 host and from there tunnels to the virtual machines via a dedicated admin network. See group_vars/layer2.yml to see what this tunneling mechanism actually looks like.
+
+#### Accessing layer2 hosts via browser
+
+- Log into the layer1 host using the following command to establish a SOCKS proxy on localhost port 1080
+  ```
+  $ ssh -i binary/hailstorm -D 1080 root@<NAME_OF_IP_OF_THE_LAYER1_HOST>
+  ```
+- Configure your browser to use a SOCKS proxy on localhost port 1080
+
+#### Accessing layer2 host consoles via VNC
+To debug installation processes, a connection to the VM console might be required. This can be achieved roughly by the follwoing approach:
+- ensure that the VMs host variables contain the following property
+  ```
+  graphics: vnc,listen=0.0.0.0,password=redhat01
+  ```
+- log into your layer1 host and use the following command to determine which port the VNC console actually runs on (you can probably also specify a fixed port number; check the virt-install documentation)
+  ```
+  # virsh dumpxml <vm_name>
+  ```
+- log into the layer1 host again to port-forward a local port to the console (the second port number needs to be changed to the port number from the XML dump).
+  ```
+  $ ssh -i binary/hailstorm -L 5901:localhost:5901 root@<NAME_OF_IP_OF_THE_LAYER1_HOST>
+  ```
+- connect your VNC viewer to localhost:5901

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -72,7 +72,7 @@ Ansible does not have a native concept of different actions such as "create the 
 The following roles exist:
 - **common**: not a role in its own sense, rather a place where tasks, handlers or templates which are used in multiple roles can be stored and referenced.
 - **layer1**: configures the layer1 host, network setup and services required by the layer2 VMs such as an export directory for kickstart files, NTP service, etc...
-- **layer1_vms**: creates the virtual machines for an inventory group and installs a base RHEL via kickstart. Since the role is applied to the layer1 host, the name of the group is passed via variable name.
+- **layer1_vms**: creates the virtual machines for an inventory group and installs a base RHEL via kickstart. Since the role is applied to the layer1 host, the name of the group is passed via variable name. This also means that all the variables/facts defined for the individual members of the group - i.e. the host that is to be instantiated - is not avaiable in the default scope. Most of the tasks iterate over the group members, so the host name is avialable as *item*. This means that you can access the actual host variables / facts via *hostvars[item].nameofvariable*.
 - **layer2_rhel**: configures the base RHEL installed in the previous step - a great place to put common configuration actions:
   - Subscribes/Unsubscribes the VM
   - Attaches it to a pool

--- a/ansible/create.yml
+++ b/ansible/create.yml
@@ -39,11 +39,11 @@
       mode: create
       group: rhosp-all
     - role: layer1_vms
-      tags: [ 'layer2','rhev','vm' ]
+      tags: [ 'layer2','rhevh', 'rhev','vm' ]
       mode: create
       group: rhevh
     - role: layer1_vms
-      tags: [ 'layer2','rhevm','vm' ]
+      tags: [ 'layer2','rhevm', 'rhev','vm' ]
       mode: create
       group: rhevm
 
@@ -54,7 +54,7 @@
     - setup:
       tags: [ 'layer2', 'rhev' ]
   roles:
-    - { role: layer2_rhel, tags: [ 'layer2','rhevm', 'rhel' ], mode: create }
+    - { role: layer2_rhel, tags: [ 'layer2','rhev', 'rhevm', 'rhel' ], mode: create }
   #  - { role: layer2_rhevm, tags: [ 'layer2','rhevm' ], mode: create }
 
 - hosts: rhevh
@@ -64,7 +64,7 @@
     - setup:
       tags: [ 'layer2', 'rhev' ]
   roles:
-    - { role: layer2_rhel, tags: [ 'layer2','rhevh', 'rhel' ], mode: create }
+    - { role: layer2_rhel, tags: [ 'layer2','rhev', 'rhevh', 'rhel' ], mode: create }
   #  - { role: layer2_rhevh, tags: [ 'layer2','rhevm' ], mode: create }
 
 - hosts: satellite

--- a/ansible/create.yml
+++ b/ansible/create.yml
@@ -13,6 +13,7 @@
         - rhosp
         - rhev
         - rhevm
+        - rhevh
   vars_prompt:
     - name: "rhsm_username"
       prompt: "what is your Red Hat Subscription Manager username?"

--- a/ansible/group_vars/ose3-node.yml
+++ b/ansible/group_vars/ose3-node.yml
@@ -1,4 +1,4 @@
-poolid: 8a85f9814f220b7c014f221083430791
+#poolid: 8a85f9814f220b7c014f221083430791
 repos:
   - rhel-7-server-rpms
   - rhel-7-server-extras-rpms

--- a/ansible/group_vars/rhel6.yml
+++ b/ansible/group_vars/rhel6.yml
@@ -3,3 +3,4 @@ os_type: linux
 os_variant: rhel6
 fstype: ext4
 selinux_mode: permissive
+poolid: 8a85f9814f220b7c014f221083430791

--- a/ansible/group_vars/rhel7.yml
+++ b/ansible/group_vars/rhel7.yml
@@ -3,3 +3,4 @@ os_type: linux
 os_variant: rhel7
 fstype: xfs
 selinux_mode: enforcing
+poolid: 8a85f9814f220b7c014f221083430791

--- a/ansible/group_vars/rhevh.yml
+++ b/ansible/group_vars/rhevh.yml
@@ -1,0 +1,7 @@
+#poolid: 8a85f9843e3d687a013e3ddd46dd07f1
+
+repos:
+  - rhel-7-server-rpms
+  - rhel-7-server-rhev-mgmt-agent-rpms
+
+packages:

--- a/ansible/host_vars/rhevh1.yml
+++ b/ansible/host_vars/rhevh1.yml
@@ -25,10 +25,3 @@ root_password: redhat01
 graphics: vnc,listen=0.0.0.0,password=redhat01
 
 ansible_host: 192.168.103.11
-
-poolid: 8a85f9843e3d687a013e3ddd46dd07f1
-
-repos:
-  - rhel-7-server-rpms
-  - rhel-7-server-rhev-mgmt-agent-rpms
-

--- a/ansible/host_vars/rhevh2.yml
+++ b/ansible/host_vars/rhevh2.yml
@@ -23,10 +23,3 @@ nic:
 hostname: rhevh2.example.com
 root_password: redhat01
 ansible_host: 192.168.103.12
-
-poolid: 8a85f9843e3d687a013e3ddd46dd07f1
-
-repos:
-  - rhel-7-server-rpms
-  - rhel-7-server-rhev-mgmt-agent-rpms
-

--- a/ansible/host_vars/rhevm.yml
+++ b/ansible/host_vars/rhevm.yml
@@ -24,7 +24,7 @@ hostname: rhevm.example.com
 root_password: redhat01
 ansible_host: 192.168.103.10
 
-poolid: 8a85f9843e3d687a013e3ddd46dd07f1
+#poolid: 8a85f9843e3d687a013e3ddd46dd07f1
 
 repos:
   - rhel-6-server-rpms
@@ -32,4 +32,3 @@ repos:
   - rhel-6-server-rhevm-3.6-rpms
   - jb-eap-6-for-rhel-6-server-rpms
 packages: rhevm
-

--- a/ansible/host_vars/rhosp-director.yml
+++ b/ansible/host_vars/rhosp-director.yml
@@ -28,7 +28,7 @@ hostname: rhosp-director.example.com
 root_password: redhat01
 ansible_host: 192.168.103.30
 
-poolid: 8a85f9814f220b7c014f221083430791
+#poolid: 8a85f9814f220b7c014f221083430791
 repos:
   - rhel-7-server-rpms
   - rhel-7-server-optional-rpms

--- a/ansible/hosts
+++ b/ansible/hosts
@@ -1,13 +1,18 @@
+# lists all other groups
 [all:children]
 layer1
+rhev
 rhosp-all
-ose3-node
 satellite
+ose3-node
 
+# the layer1 group should only contain a single server called layer1
+# whose IP address is specified in the ansible_host property in host_vars/layer1.yml
 [layer1]
 layer1
-rhev
 
+# everything on layer2 - this is important because group_vars/layer2.yml configures
+# the ssh proxy command used to communicate with all layer2 hosts
 [layer2:children]
 ose3-node
 satellite
@@ -23,46 +28,58 @@ ose3-master
 [satellite]
 satellite
 
+# A list of all OpenStack subgroups
 [rhosp-all:children]
 rhosp-director
 rhosp-undercloud
 
+# The single system where osp-director will be installed to
 [rhosp-director]
 rhosp-director
 
+# The groups that make up the osp undercloud (i.e. compute, control and potentially storage)
 [rhosp-undercloud:children]
 rhosp-compute
 rhosp-control
 
+# The group of all osp compute nodes
 [rhosp-compute]
 rhosp-compute1
 rhosp-compute2
 rhosp-compute3
 
+# The group of all osp control nodes
 [rhosp-control]
 rhosp-control1
 rhosp-control2
 rhosp-control3
 
+# a group required to store a common configuration for IPMI emulation between the layer1 host and the osp-director
 [ssh-kvm-powermanagement-emulation]
 rhosp-director
 layer1
 
+# the list of groups that make up RHEV
 [rhev:children]
 rhevm
 rhevh
 
+# the single node that is RHEV-Manager
 [rhevm]
 rhevm
 
+# the nodes that are RHEV-Hypervisor
 [rhevh]
 rhevh1
 rhevh2
 
+# All layer2 nodes that are installed with RHEL7
 [rhel7:children]
 rhosp-all
 satellite
 rhevh
+ose3-node
 
+# All layer2 nodes that are installed with RHEL6
 [rhel6:children]
 rhevm

--- a/ansible/roles/layer1_vms/tasks/destroy_vms.yml
+++ b/ansible/roles/layer1_vms/tasks/destroy_vms.yml
@@ -16,6 +16,9 @@
   when: "{{ hostvars[item].name in virt_vms.list_vms }}"
   with_items: "{{ groups[group] }}"
   ignore_errors: true
+- name: refresh pool to allow unused images to be deleted
+  command: virsh pool-refresh {{ storage_default.name }}
+  changed_when: false
 - name: remove vm volumes
   command: virsh vol-delete {{ hostvars[item].disk.path }} --pool {{ storage_default.name }}
   when: "{{ hostvars[item].name in virt_vms.list_vms }}"

--- a/ansible/roles/layer1_vms/templates/kickstart.cfg.j2
+++ b/ansible/roles/layer1_vms/templates/kickstart.cfg.j2
@@ -37,9 +37,9 @@ rootpw "{{ hostvars[item].root_password }}"
 # System services
 services --enabled="chronyd"
 # System timezone
-timezone Europe/Berlin --utc 
+timezone Europe/Berlin --utc
 # System bootloader configuration
-bootloader --append=" crashkernel=auto" --location=mbr 
+bootloader --append=" crashkernel=auto" --location=mbr
 # Partition clearing informationi
 zerombr
 clearpart --all --initlabel
@@ -65,6 +65,6 @@ cat  << xxEOFxx >> /root/.ssh/authorized_keys
 xxEOFxx
 # RHEL6 bug workaround #1
 sed -i 's/dhcp/static/' /etc/sysconfig/network-scripts/ifcfg-eth1
-# RHEL6 bug workaround #2
+# RHEL6 bug workaround #2 # TODO: this will break for satellite since it will try to fetch the policy from itself.... hence permissive mode
 # yum localinstall -y  http://192.168.103.20/pub/selinux-policy-3.7.19-279.el6_7.8.noarch.rpm http://192.168.103.20/pub/selinux-policy-targeted-3.7.19-279.el6_7.8.noarch.rpm
 %end

--- a/ansible/roles/layer2_rhel/tasks/prepare_host.yml
+++ b/ansible/roles/layer2_rhel/tasks/prepare_host.yml
@@ -1,10 +1,9 @@
 - name: subscribe RHEL
   redhat_subscription: state=present username={{ rhsm_username }} password={{ rhsm_password }} autosubscribe=false
 - name: check subscriptions
-  shell: subscription-manager list --consumed | grep "Pool ID"
+  shell: subscription-manager list --consumed | grep -q "Pool ID" || true
   register: subscription_list
   changed_when: False
-  ignore_errors: True
 - name: attach to pool
   command: 'subscription-manager attach --pool={{ poolid }}'
   when: subscription_list.stdout is not defined or poolid != subscription_list.stdout | regex_replace('Pool ID:\\s+(\\S*).*', '\\1')

--- a/ansible/roles/layer2_rhel/tasks/prepare_host.yml
+++ b/ansible/roles/layer2_rhel/tasks/prepare_host.yml
@@ -1,7 +1,7 @@
 - name: subscribe RHEL
   redhat_subscription: state=present username={{ rhsm_username }} password={{ rhsm_password }} autosubscribe=false
 - name: check subscriptions
-  shell: subscription-manager list --consumed | grep -q "Pool ID" || true
+  shell: subscription-manager list --consumed | grep "Pool ID" || true
   register: subscription_list
   changed_when: False
 - name: attach to pool
@@ -16,15 +16,13 @@
   notify:
     - reboot server
     - waiting for server to come back
-  when: not (packages is undefined or packages is none or pacakges | trim == '')
-- block:
-  - name: enable services
-    service: name={{ item }} enabled=yes state=started
-    with_items: "{{ enable_services }}"
-  when: enable_services is defined
-- block:
-  - name: disable services
-    service: name={{item}} enabled=no state=stopped
-    with_items: "{{ disable_services }}"
-  when: disable_services is defined
+  when: not (packages is undefined or packages is none or packages | trim == '')
+- name: enable services
+  service: name={{ item }} enabled=yes state=started
+  with_items: "{{ enable_services }}"
+  when: not (enable_services is undefined or enable_services is none or enable_services | trim == '')
+- name: disable services
+  service: name={{item}} enabled=no state=stopped
+  with_items: "{{ disable_services }}"
+  when: not (disable_services is undefined or disable_services is none or disable_services | trim == '')
 - meta: flush_handlers

--- a/ansible/roles/layer2_rhel/tasks/prepare_host.yml
+++ b/ansible/roles/layer2_rhel/tasks/prepare_host.yml
@@ -17,6 +17,7 @@
   notify:
     - reboot server
     - waiting for server to come back
+  when: not (packages is undefined or packages is none or pacakges | trim == '')
 - block:
   - name: enable services
     service: name={{ item }} enabled=yes state=started

--- a/ansible/roles/layer2_rhel/tasks/prepare_host.yml
+++ b/ansible/roles/layer2_rhel/tasks/prepare_host.yml
@@ -17,6 +17,7 @@
     - reboot server
     - waiting for server to come back
   when: not (packages is undefined or packages is none or packages | trim == '')
+# next tasks error message is probably the same as this: https://github.com/ansible/ansible/issues/14383
 - name: enable services
   service: name={{ item }} enabled=yes state=started
   with_items: "{{ enable_services }}"


### PR DESCRIPTION
Hi Ade,

It works for me now :-) here are my changes:

- Did some more documentation work
- Moved the common rhevh config items into  group_var/rhevh.yml <- so both will be guaranteed to be in sync config-wise
- Moved the common poolid into group_var/rhel{6,7} <- so we have less places to change the pool id if different users work with the demo
- Added to the tagging of tasks to ensure it works with the tags “rhev”, “rhevm" and “rhevh"
- Added a check to skip the install packages task if no packages are specified
- Fixed the problem that virtual images cannot be deleted
- Removed some unnecessary error messages in the log when subscription is not there yet